### PR TITLE
generalize shutdown exception handling

### DIFF
--- a/franka_lock_unlock/franka_client.py
+++ b/franka_lock_unlock/franka_client.py
@@ -61,8 +61,8 @@ class FrankaClient(ABC):
         assert self._is_active_token(), "Cannot shutdown without an active control token."
         try:
             self._session.post(urljoin(self._hostname, '/admin/api/shutdown'), json={'token': self._token})
-        except ConnectionError as _:
-            # Sometimes, the server can shut down before sending a response, possibly raising an exception.
+        except requests.exceptions.RequestException as _:
+            # Sometimes, the server can shut down before sending a complete response, possibly raising an exception.
             # Anyways, the server has still received the request, thus the robot shutdown procedure will start.
             # So, we can ignore the cases when these exceptions are raised.
             pass


### PR DESCRIPTION
I got a couple of different exceptions when the machine shuts down while sending the response.
These are apparently included in the more general RequestException.

As requested in https://github.com/jk-ethz/franka_lock_unlock/pull/10#issuecomment-3407429642